### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(name='transformer-xh',
           'dgl',
           'tqdm',
           'pytorch_transformers',
-          'fuzzywuzzy'
+          'rapidfuzz'
       ], 
       )

--- a/transformer-xh/utils.py
+++ b/transformer-xh/utils.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import re
-from fuzzywuzzy import fuzz, process as fuzzy_process
+from rapidfuzz import fuzz, process as fuzzy_process
 import numpy as np
 
 
@@ -20,7 +20,7 @@ def fuzzy_find(entities, sentence):
             final_word = item.split()[-1]
             # from end
             retry = False
-            while fuzz.partial_ratio(final_word.lower(), matched) < 80:
+            while not fuzz.partial_ratio(final_word.lower(), matched, score_cutoff=80):
                 retry = True
                 end = len(item) - len(final_word)
                 while end > 0 and item[end - 1].isspace():
@@ -41,7 +41,7 @@ def fuzzy_find(entities, sentence):
             # from start
             retry = False
             first_word = item.split()[0]
-            while fuzz.partial_ratio(first_word.lower(), matched) < 80:
+            while not fuzz.partial_ratio(first_word.lower(), matched, score_cutoff=80):
                 retry = True
                 start = len(first_word)
                 while start < len(item) and item[start].isspace():

--- a/utils.py
+++ b/utils.py
@@ -2,7 +2,7 @@
 # Licensed under the MIT license.
 
 import re
-from fuzzywuzzy import fuzz, process as fuzzy_process
+from rapidfuzz import fuzz, process as fuzzy_process
 import numpy as np
 
 
@@ -20,7 +20,7 @@ def fuzzy_find(entities, sentence):
             final_word = item.split()[-1]
             # from end
             retry = False
-            while fuzz.partial_ratio(final_word.lower(), matched) < 80:
+            while not fuzz.partial_ratio(final_word.lower(), matched, score_cutoff=80):
                 retry = True
                 end = len(item) - len(final_word)
                 while end > 0 and item[end - 1].isspace():
@@ -41,7 +41,7 @@ def fuzzy_find(entities, sentence):
             # from start
             retry = False
             first_word = item.split()[0]
-            while fuzz.partial_ratio(first_word.lower(), matched) < 80:
+            while not fuzz.partial_ratio(first_word.lower(), matched, score_cutoff=80):
                 retry = True
                 start = len(first_word)
                 while start < len(item) and item[start].isspace():


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy